### PR TITLE
adding password pepper option (empty by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ contains an `ok` field that is either true or false, indicating the success or f
    * `autopass`: automatically generate an (unrecoverable) password if none is supplied - mostly good for testing, default: true
    * `mustrepeat`: you must provide a `repeat` argument (a repeat of the password) when setting a password
    * `resetperiod`: duration in millis that a password reset token is valid, default: 24 hours
+   * `pepper`: used in addition to password salts, a pepper is very similar but is stored in code instead of a database.
 
 To set options, do so when you load the plugin:
 

--- a/default-options.json
+++ b/default-options.json
@@ -6,6 +6,7 @@
   "resetperiod": 86400000,
   "confirm": false,
   "oldsha": true,
+  "pepper": "",
   "user": {
     "fields": [
       {

--- a/test/pepper-register-login.test.js
+++ b/test/pepper-register-login.test.js
@@ -1,0 +1,117 @@
+/* Copyright (c) 2010-2013 Richard Rodger */
+'use strict'
+
+var Seneca = require('seneca')
+
+var _ = require('lodash')
+
+var Lab = require('lab')
+var Code = require('code')
+var lab = exports.lab = Lab.script()
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
+var expect = Code.expect
+
+var si = Seneca()
+if (si.version >= '2.0.0'){
+  si
+    .use(require('seneca-entity'))
+}
+si
+  .use('../user', { pepper:'Please generate your own pepper for production' })
+
+var user1Data = {
+  nick: 'nick1',
+  email: 'nick1@example.com',
+  password: 'test1test',
+  repeat: 'test1test',
+  active: true
+}
+
+var user2Data = {
+  nick: 'nick2',
+  email: 'nick2@example.com',
+  password: 'test2test',
+  repeat: 'test2test',
+  active: true
+}
+
+suite('seneca-user register-login suite tests ', function () {
+  before({}, function (done) {
+    si.ready(function (err) {
+      if (err) {
+        return process.exit(!console.error(err))
+      }
+
+      done()
+    })
+  })
+
+  test('user/register test', function (done) {
+    si.act(_.extend({role: 'user', cmd: 'register'}, user1Data), function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.user.repeat).to.not.exist()
+      expect(user1Data.nick, data.nick).to.exist()
+      done(err)
+    })
+  })
+
+  test('user/register test', function (done) {
+    si.act(_.extend({role: 'user', cmd: 'register'}, user2Data), function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.user.nick).to.equal(user2Data.nick)
+      done(err)
+    })
+  })
+
+  test('user/login test', function (done) {
+    si.act({role: 'user', cmd: 'login', nick: user1Data.nick, password: user1Data.password}, function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.ok).to.exist()
+      expect(data.why).to.equal('password')
+      expect(data.login).to.exist()
+      expect(data.user).to.exist()
+      expect(data.login.repeat).to.not.exist()
+      expect(data.user.repeat).to.not.exist()
+      expect(data.login.token).to.exist()
+      done(err)
+    })
+  })
+
+  test('user/register unique nick test', function (done) {
+    si.act(_.extend({role: 'user', cmd: 'register'}, user1Data), function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.ok).to.be.false()
+      expect(data.why).to.equal('nick-exists')
+      done(err)
+    })
+  })
+
+  test('user/register password mismatch test', function (done) {
+    si.act(_.extend({role: 'user', cmd: 'register'}, {nick: 'npm', password: 'a', repeat: 'b'}), function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.ok).to.be.false()
+      expect(data.why).to.equal('password_mismatch')
+      done(err)
+    })
+  })
+
+  test('user/login invalid user test', function (done) {
+    si.act({role: 'user', cmd: 'login', nick: user1Data.nick + 'x', password: user1Data.password}, function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.ok).to.be.false()
+      expect(data.why).to.equal('user-not-found')
+      done(err)
+    })
+  })
+
+  test('user/login invalid password test', function (done) {
+    si.act({role: 'user', cmd: 'login', nick: user1Data.nick, password: user1Data.password + 'x'}, function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.ok).to.be.false()
+      expect(data.why).to.equal('invalid-password')
+      done(err)
+    })
+  })
+})

--- a/user.js
+++ b/user.js
@@ -35,6 +35,7 @@ module.exports = function user (options) {
   // Use this when you want to load multiple versions of the plugin
   // and expose them via different patterns.
   var role = options.role
+  var pepper = options.pepper
 
   // # Action patterns
   // These define the pattern interface for this plugin.
@@ -383,7 +384,7 @@ module.exports = function user (options) {
     var salt = args.salt || create_salt()
     var password = args.password
 
-    hasher(password + salt, options.rounds, function (pass) {
+    hasher(pepper + password + salt, options.rounds, function (pass) {
       done(null, {ok: true, pass: pass, salt: salt})
     })
   }


### PR DESCRIPTION
Hi,

small change to allow plugin users to set a password "pepper" when configuring seneca-user.

A pepper is similar to a password salt, but stored in code instead. There is only one pepper per site, and it is used to add a little additional protection against database compromise.