### PR TITLE
Pattern role: user, cmd: auth should validate if the login is active

### DIFF
--- a/test/validate-token.test.js
+++ b/test/validate-token.test.js
@@ -1,0 +1,72 @@
+/* Copyright (c) 2010-2013 Richard Rodger */
+'use strict'
+
+var Seneca = require('seneca')
+
+var _ = require('lodash')
+
+var Lab = require('lab')
+var Code = require('code')
+var lab = exports.lab = Lab.script()
+var suite = lab.suite
+var test = lab.test
+var before = lab.before
+var expect = Code.expect
+
+var si = Seneca()
+
+if (si.version >= '2.0.0'){
+  si
+    .use(require('seneca-entity'))
+}
+si
+  .use('../user')
+
+var user1Data = {
+  nick: 'nick1',
+  email: 'nick1@example.com',
+  password: 'test1test',
+  salt: 'something',
+  active: true
+}
+
+suite('seneca-user login and token validation suite tests ', function () {
+  before({}, function (done) {
+    si.ready(function (err) {
+      if (err) return process.exit(!console.error(err))
+      done()
+    })
+  })
+
+  test('user/register test', function (done) {
+    si.act(_.extend({role: 'user', cmd: 'register'}, user1Data), function (err, data) {
+      expect(err).to.not.exist()
+      expect(data.user.nick).to.equal(user1Data.nick)
+      done(err)
+    })
+  })
+
+  test('user/login validate token test', function (done) {
+    si.act({role: 'user', cmd: 'login', nick: user1Data.nick, password: user1Data.password}, function (err, data) {
+      si.act({role: 'user', cmd: 'auth', token: data.login.token}, function (err, data_auth) {
+        expect(err).to.not.exist()
+        expect(data_auth.ok).to.be.true()
+        expect(data.user.nick).to.equal(data_auth.user.nick)
+        done(err)
+      })
+    })
+  })
+
+  test('user/login validate token after logout', function (done) {
+    si.act({role: 'user', cmd: 'login', nick: user1Data.nick, password: user1Data.password}, function (err, data) {
+      si.act({role: 'user', cmd: 'logout', token: data.login.token}, function (err, data_logout) {
+        si.act({role: 'user', cmd: 'auth', token: data.login.token}, function (err, data_auth) {
+          expect(err).to.not.exist()
+          expect(data_auth.ok).to.be.false()
+          expect(data_auth.why).to.equal('login-inactive')
+          done(err)
+        })
+      })
+    })
+  })
+})

--- a/test/validate-token.test.js
+++ b/test/validate-token.test.js
@@ -34,15 +34,7 @@ suite('seneca-user login and token validation suite tests ', function () {
   before({}, function (done) {
     si.ready(function (err) {
       if (err) return process.exit(!console.error(err))
-      done()
-    })
-  })
-
-  test('user/register test', function (done) {
-    si.act(_.extend({role: 'user', cmd: 'register'}, user1Data), function (err, data) {
-      expect(err).to.not.exist()
-      expect(data.user.nick).to.equal(user1Data.nick)
-      done(err)
+      si.act(_.extend({role: 'user', cmd: 'register'}, user1Data), done)
     })
   })
 

--- a/user.js
+++ b/user.js
@@ -724,6 +724,10 @@ module.exports = function user (options) {
         return done(null, {ok: false, token: args.token, why: 'login-not-found'})
       }
 
+      if (!login.active) {
+        return done(null, {ok: false, token: args.token, why: 'login-inactive'})
+      }
+
       userent.load$({id: login.user}, function (err, user) {
         if (err) return done(err)
 


### PR DESCRIPTION
Old behaviour: Even after logout the token was considered valid.
New behaviour: After logout the validateToken returns 'login-inactive'