### PR TITLE
Fixed a bug where updating a password and another parameter only upda…

### DIFF
--- a/user.js
+++ b/user.js
@@ -1041,7 +1041,7 @@ module.exports = function user (options) {
         if (pwd === pwd2 && 1 < pwd.length) {
           seneca.act('role: ' + role + ', cmd: change_password', _.extend({}, q, {password: pwd}), function (err, userpwd) {
             if (err) return done(err, {ok: false, why: err})
-            user = userpwd
+            user.pass = userpwd.user.pass
           })
         }
         else {


### PR DESCRIPTION
…ted the password

`cmd_change_password` returns an object of the format `{ok:..., user:...}`.
We need to use `userpwd.user` instead of `userpwd`.
The test `seneca-user update suite tests  user/login user test after update and change password`  is only passed because `ser.name = args.name || pwdupdate.name` is hardcoded in there.